### PR TITLE
Add multi-API auth support and enhanced configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,18 @@
 VITE_API_BASE_URL=http://localhost:8080
 PORT=8080
+
+# Multi-API Configuration
+# Define your APIs here - each API will be available at /api/{API_NAME}
+# Format: API_CONFIGS='{API_NAME}:{API_URL},{API_NAME2}:{API_URL2}'
+
+API_CONFIGS=infractions:http://localhost:8000
+
+# Example with multiple APIs:
+# API_CONFIGS=infractions:http://localhost:8000,users:http://localhost:8001,orders:http://localhost:8002
+
+# Default API configuration
+DEFAULT_TENANT=business
+DEFAULT_LANGUAGE=en
+
+# Authentication (optional)
+# API_TOKEN=your_bearer_token_here

--- a/.env
+++ b/.env
@@ -3,12 +3,13 @@ PORT=8080
 
 # Multi-API Configuration
 # Define your APIs here - each API will be available at /api/{API_NAME}
-# Format: API_CONFIGS='{API_NAME}:{API_URL},{API_NAME2}:{API_URL2}'
+# Enhanced Format: API_CONFIGS='{API_NAME}:{API_URL}:{LABEL}:{AUTH_TOKEN},{API_NAME2}:{API_URL2}:{LABEL2}:{AUTH_TOKEN2}'
+# Simple Format: API_CONFIGS='{API_NAME}:{API_URL},{API_NAME2}:{API_URL2}' (backwards compatible)
 
-API_CONFIGS=infractions:http://localhost:8000
+API_CONFIGS=infractions:http://localhost:8000:local,oathkeeper:https://oathkeeperapiurl.com:oathkeeper:your_bearer_token_here
 
 # Example with multiple APIs:
-# API_CONFIGS=infractions:http://localhost:8000,users:http://localhost:8001,orders:http://localhost:8002
+# API_CONFIGS=infractions:http://localhost:8000:local,users:http://localhost:8001:staging:token123,orders:http://localhost:8002:production:token456
 
 # Default API configuration
 DEFAULT_TENANT=business

--- a/client/components/ApiDashboard.tsx
+++ b/client/components/ApiDashboard.tsx
@@ -277,6 +277,17 @@ export function ApiDashboard({ onApiSelect, selectedApi }: ApiDashboardProps) {
                   <div>
                     <div className="flex items-center space-x-2">
                       <h3 className="font-semibold text-lg">{api.name}</h3>
+                      {api.label && (
+                        <Badge variant="secondary" className="text-xs">
+                          {api.label}
+                        </Badge>
+                      )}
+                      {api.requiresAuth && (
+                        <div className="flex items-center space-x-1">
+                          <Shield className="h-4 w-4 text-blue-600" />
+                          <span className="text-xs text-blue-600">Auth</span>
+                        </div>
+                      )}
                       {selectedApi === api.name && (
                         <Badge variant="outline" className="text-xs">
                           Active

--- a/client/components/ApiDashboard.tsx
+++ b/client/components/ApiDashboard.tsx
@@ -19,6 +19,7 @@ import {
   Zap,
   Globe,
   Settings,
+  Shield,
 } from "lucide-react";
 import { ApiStatus } from "@shared/apis";
 import { apiManager } from "@/lib/apiManager";

--- a/client/components/ApiSelector.tsx
+++ b/client/components/ApiSelector.tsx
@@ -97,7 +97,22 @@ export function ApiSelector({
             <div className="flex items-center justify-between w-full">
               <div className="flex items-center space-x-2">
                 {getStatusIcon(api.status)}
-                <span>{api.name}</span>
+                <div className="flex flex-col">
+                  <div className="flex items-center space-x-2">
+                    <span>{api.name}</span>
+                    {api.label && (
+                      <Badge variant="outline" className="text-xs">
+                        {api.label}
+                      </Badge>
+                    )}
+                    {api.requiresAuth && (
+                      <Shield className="h-3 w-3 text-blue-600" title="Requires Authentication" />
+                    )}
+                  </div>
+                  <span className="text-xs text-muted-foreground truncate max-w-[200px]">
+                    {api.baseUrl}
+                  </span>
+                </div>
               </div>
               <Badge
                 variant={

--- a/client/components/ApiSelector.tsx
+++ b/client/components/ApiSelector.tsx
@@ -93,7 +93,10 @@ export function ApiSelector({
                 </Badge>
               )}
               {apis.find((api) => api.name === value)?.requiresAuth && (
-                <Shield className="h-3 w-3 text-blue-600" title="Requires Authentication" />
+                <Shield
+                  className="h-3 w-3 text-blue-600"
+                  title="Requires Authentication"
+                />
               )}
             </div>
           )}
@@ -114,7 +117,10 @@ export function ApiSelector({
                       </Badge>
                     )}
                     {api.requiresAuth && (
-                      <Shield className="h-3 w-3 text-blue-600" title="Requires Authentication" />
+                      <Shield
+                        className="h-3 w-3 text-blue-600"
+                        title="Requires Authentication"
+                      />
                     )}
                   </div>
                   <span className="text-xs text-muted-foreground truncate max-w-[200px]">

--- a/client/components/ApiSelector.tsx
+++ b/client/components/ApiSelector.tsx
@@ -87,6 +87,14 @@ export function ApiSelector({
                 apis.find((api) => api.name === value)?.status || "unknown",
               )}
               <span>{value}</span>
+              {apis.find((api) => api.name === value)?.label && (
+                <Badge variant="outline" className="text-xs">
+                  {apis.find((api) => api.name === value)?.label}
+                </Badge>
+              )}
+              {apis.find((api) => api.name === value)?.requiresAuth && (
+                <Shield className="h-3 w-3 text-blue-600" title="Requires Authentication" />
+              )}
             </div>
           )}
         </SelectValue>

--- a/client/components/ApiSelector.tsx
+++ b/client/components/ApiSelector.tsx
@@ -9,7 +9,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { ApiConfig } from "@shared/apis";
 import { apiManager } from "@/lib/apiManager";
-import { CheckCircle2, AlertCircle, Clock } from "lucide-react";
+import { CheckCircle2, AlertCircle, Clock, Shield } from "lucide-react";
 
 interface ApiSelectorProps {
   value?: string;

--- a/client/pages/MultiApiDashboard.tsx
+++ b/client/pages/MultiApiDashboard.tsx
@@ -46,6 +46,7 @@ export default function MultiApiDashboard() {
   "page": 0,
   "perPage": 10
 }`);
+  const [bearerToken, setBearerToken] = useState("");
   const [response, setResponse] = useState<any>(null);
   const [isLoading, setIsLoading] = useState(false);
 

--- a/client/pages/MultiApiDashboard.tsx
+++ b/client/pages/MultiApiDashboard.tsx
@@ -272,6 +272,19 @@ export default function MultiApiDashboard() {
                   </div>
 
                   <div className="space-y-2">
+                    <Label>Bearer Token (Optional)</Label>
+                    <Input
+                      type="password"
+                      value={bearerToken}
+                      onChange={(e) => setBearerToken(e.target.value)}
+                      placeholder="Enter Bearer token for authentication"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      If provided, will be added as Authorization: Bearer header
+                    </p>
+                  </div>
+
+                  <div className="space-y-2">
                     <Label>Headers (JSON)</Label>
                     <Textarea
                       value={requestHeaders}

--- a/client/pages/MultiApiDashboard.tsx
+++ b/client/pages/MultiApiDashboard.tsx
@@ -81,6 +81,11 @@ export default function MultiApiDashboard() {
         return;
       }
 
+      // Add Bearer token if provided
+      if (bearerToken.trim()) {
+        headers.Authorization = `Bearer ${bearerToken.trim()}`;
+      }
+
       // Prepare request options
       const options: RequestInit = {
         method: requestMethod,

--- a/client/pages/MultiApiDashboard.tsx
+++ b/client/pages/MultiApiDashboard.tsx
@@ -145,6 +145,11 @@ export default function MultiApiDashboard() {
       headers = {};
     }
 
+    // Add Bearer token if provided
+    if (bearerToken.trim()) {
+      headers.Authorization = `Bearer ${bearerToken.trim()}`;
+    }
+
     let command = `curl -X ${requestMethod} \\\n`;
     command += `  '${api.baseUrl}${requestEndpoint}' \\\n`;
 

--- a/server/routes/config.ts
+++ b/server/routes/config.ts
@@ -4,12 +4,7 @@ import { parseApiConfigs } from "../../shared/apis";
 export const handleConfig: RequestHandler = (req, res) => {
   try {
     const apiConfigString = process.env.API_CONFIGS || "";
-    console.log("API_CONFIGS from env:", apiConfigString);
-    console.log("DEFAULT_TENANT from env:", process.env.DEFAULT_TENANT);
-    console.log("DEFAULT_LANGUAGE from env:", process.env.DEFAULT_LANGUAGE);
-
     const apis = parseApiConfigs(apiConfigString);
-    console.log("Parsed APIs:", apis);
 
     const config = {
       apis,

--- a/server/routes/config.ts
+++ b/server/routes/config.ts
@@ -4,7 +4,12 @@ import { parseApiConfigs } from "../../shared/apis";
 export const handleConfig: RequestHandler = (req, res) => {
   try {
     const apiConfigString = process.env.API_CONFIGS || "";
+    console.log("API_CONFIGS from env:", apiConfigString);
+    console.log("DEFAULT_TENANT from env:", process.env.DEFAULT_TENANT);
+    console.log("DEFAULT_LANGUAGE from env:", process.env.DEFAULT_LANGUAGE);
+
     const apis = parseApiConfigs(apiConfigString);
+    console.log("Parsed APIs:", apis);
 
     const config = {
       apis,

--- a/server/routes/proxy.ts
+++ b/server/routes/proxy.ts
@@ -45,9 +45,11 @@ export const createApiProxy: RequestHandler = async (req, res) => {
       "Content-Type": "application/json",
     };
 
-    // Forward authorization header if present
+    // Forward authorization header if present, otherwise use API config token
     if (req.headers.authorization) {
       headers.Authorization = req.headers.authorization;
+    } else if (apiConfig.requiresAuth && apiConfig.authToken) {
+      headers.Authorization = `Bearer ${apiConfig.authToken}`;
     }
 
     // Forward custom headers (tenant, language, etc.)

--- a/shared/apis.ts
+++ b/shared/apis.ts
@@ -35,10 +35,12 @@ export function parseApiConfigs(configString?: string): ApiConfig[] {
   return configString
     .split(",")
     .map((config) => {
-      const parts = config.split(":").map(part => part.trim());
+      const parts = config.split(":").map((part) => part.trim());
 
       if (parts.length < 2) {
-        console.warn(`Invalid API config format: ${config}. Expected at least name:url`);
+        console.warn(
+          `Invalid API config format: ${config}. Expected at least name:url`,
+        );
         return null;
       }
 

--- a/shared/apis.ts
+++ b/shared/apis.ts
@@ -5,6 +5,9 @@ export interface ApiConfig {
   lastChecked?: Date;
   response_time?: number;
   description?: string;
+  label?: string;
+  requiresAuth?: boolean;
+  authToken?: string;
 }
 
 export interface ApiHealthCheck {

--- a/shared/apis.ts
+++ b/shared/apis.ts
@@ -28,25 +28,47 @@ export interface MultiApiResponse<T = any> {
 }
 
 // Parse API configs from environment variable
+// Supports both simple format: "name:url" and enhanced format: "name:url:label:token"
 export function parseApiConfigs(configString?: string): ApiConfig[] {
   if (!configString) return [];
 
   return configString
     .split(",")
     .map((config) => {
-      const colonIndex = config.indexOf(":");
-      if (colonIndex === -1) {
-        console.warn(`Invalid API config format: ${config}`);
+      const parts = config.split(":").map(part => part.trim());
+
+      if (parts.length < 2) {
+        console.warn(`Invalid API config format: ${config}. Expected at least name:url`);
         return null;
       }
 
-      const name = config.substring(0, colonIndex).trim();
-      const baseUrl = config.substring(colonIndex + 1).trim();
+      const [name, baseUrl, label, authToken] = parts;
+
+      // Reconstruct URL if it was split by colons (for http/https protocols)
+      let finalBaseUrl = baseUrl;
+      if (parts.length > 2 && (baseUrl === "http" || baseUrl === "https")) {
+        finalBaseUrl = `${baseUrl}:${parts[2]}`;
+        // Adjust other parts if URL contained protocol
+        const adjustedParts = [name, finalBaseUrl, ...parts.slice(3)];
+        const [, , adjustedLabel, adjustedAuthToken] = adjustedParts;
+
+        return {
+          name,
+          baseUrl: finalBaseUrl,
+          status: "unknown" as const,
+          label: adjustedLabel || undefined,
+          requiresAuth: adjustedAuthToken ? true : false,
+          authToken: adjustedAuthToken || undefined,
+        };
+      }
 
       return {
         name,
-        baseUrl,
+        baseUrl: finalBaseUrl,
         status: "unknown" as const,
+        label: label || undefined,
+        requiresAuth: authToken ? true : false,
+        authToken: authToken || undefined,
       };
     })
     .filter((config) => config !== null) as ApiConfig[];


### PR DESCRIPTION
## Changes Made

### Environment Configuration
- Enhanced `.env` file with comprehensive multi-API configuration examples
- Added support for enhanced API config format: `API_NAME:API_URL:LABEL:AUTH_TOKEN`
- Maintained backwards compatibility with simple format: `API_NAME:API_URL`
- Added default tenant and language configuration options

### API Configuration Parser
- Updated `parseApiConfigs()` function in `shared/apis.ts` to support enhanced format
- Added new optional fields to `ApiConfig` interface:
  - `label`: Display label for API identification
  - `requiresAuth`: Boolean flag indicating authentication requirement
  - `authToken`: Bearer token for API authentication
- Improved URL parsing to handle protocol colons correctly

### UI Components
- **ApiDashboard**: Added visual indicators for API labels and authentication status using Shield icon
- **ApiSelector**: Enhanced dropdown to display API labels, authentication status, and base URLs
- **MultiApiDashboard**: Added Bearer token input field for manual authentication override

### Proxy Server
- Updated proxy route to automatically use configured auth tokens when no authorization header is provided
- Maintains existing behavior of forwarding user-provided authorization headers

### Visual Enhancements
- Added Shield icon from lucide-react for authentication indicators
- Implemented Badge components to display API labels
- Added tooltips and helper text for better user experience

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a2b1dd34da0b42799fe85057962098b6/zenith-zone)

👀 [Preview Link](https://a2b1dd34da0b42799fe85057962098b6-zenith-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a2b1dd34da0b42799fe85057962098b6</projectId>-->
<!--<branchName>zenith-zone</branchName>-->