### PR TITLE
Replace API config fetch with environment variables

### DIFF
--- a/client/components/ApiDashboard.tsx
+++ b/client/components/ApiDashboard.tsx
@@ -38,7 +38,7 @@ export function ApiDashboard({ onApiSelect, selectedApi }: ApiDashboardProps) {
   const loadApiStatuses = async () => {
     setIsLoading(true);
     try {
-      await apiManager.initialize();
+      apiManager.initialize();
       const statuses = await apiManager.checkAllApisHealth();
       setApiStatuses(statuses);
       setLastRefresh(new Date());

--- a/client/components/ApiSelector.tsx
+++ b/client/components/ApiSelector.tsx
@@ -26,9 +26,9 @@ export function ApiSelector({
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const loadApis = async () => {
+    const loadApis = () => {
       try {
-        await apiManager.initialize();
+        apiManager.initialize();
         const availableApis = apiManager.getApis();
         setApis(availableApis);
 

--- a/client/lib/apiManager.ts
+++ b/client/lib/apiManager.ts
@@ -13,12 +13,11 @@ class ApiManager {
   > = new Map();
   private readonly CACHE_DURATION = 30000; // 30 seconds
 
-  // Initialize API configurations
-  async initialize(): Promise<void> {
+  // Initialize API configurations from environment variables
+  initialize(): void {
     try {
-      const response = await fetch("/api/config");
-      const data = await response.json();
-      this.configs = data.apis || [];
+      const apiConfigString = __API_CONFIGS__;
+      this.configs = parseApiConfigs(apiConfigString);
     } catch (error) {
       console.error("Failed to load API configurations:", error);
       this.configs = [];

--- a/client/lib/config.ts
+++ b/client/lib/config.ts
@@ -1,0 +1,29 @@
+// Configuration utilities for accessing build-time environment variables
+import { parseApiConfigs } from "@shared/apis";
+
+export interface AppConfig {
+  apis: ReturnType<typeof parseApiConfigs>;
+  defaults: {
+    tenant: string;
+    language: string;
+  };
+}
+
+// Get the application configuration from build-time environment variables
+export function getAppConfig(): AppConfig {
+  return {
+    apis: parseApiConfigs(__API_CONFIGS__),
+    defaults: {
+      tenant: __DEFAULT_TENANT__,
+      language: __DEFAULT_LANGUAGE__,
+    },
+  };
+}
+
+// Get default values for common configuration
+export function getDefaults() {
+  return {
+    tenant: __DEFAULT_TENANT__,
+    language: __DEFAULT_LANGUAGE__,
+  };
+}

--- a/client/pages/MultiApiDashboard.tsx
+++ b/client/pages/MultiApiDashboard.tsx
@@ -50,8 +50,8 @@ export default function MultiApiDashboard() {
 
   // Auto-select first API on mount and update endpoint
   useEffect(() => {
-    const initializeApi = async () => {
-      await apiManager.initialize();
+    const initializeApi = () => {
+      apiManager.initialize();
       const apis = apiManager.getApis();
       if (apis.length > 0 && !selectedApi) {
         setSelectedApi(apis[0].name);

--- a/client/vite-env.d.ts
+++ b/client/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+declare const __API_CONFIGS__: string;
+declare const __DEFAULT_TENANT__: string;
+declare const __DEFAULT_LANGUAGE__: string;

--- a/server/index.ts
+++ b/server/index.ts
@@ -60,7 +60,6 @@ export function createServer() {
 
   app.get("/api/demo", handleDemo);
 
-
   // Demo API endpoints (for testing when real APIs are not available)
   // These must come BEFORE the proxy routes to avoid being intercepted
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,6 @@
 import express from "express";
 import cors from "cors";
 import { handleDemo } from "./routes/demo";
-import { handleConfig } from "./routes/config";
 import { createApiProxy } from "./routes/proxy";
 import {
   handleDemoLiveness,
@@ -61,8 +60,6 @@ export function createServer() {
 
   app.get("/api/demo", handleDemo);
 
-  // API configuration endpoint
-  app.get("/api/config", handleConfig);
 
   // Demo API endpoints (for testing when real APIs are not available)
   // These must come BEFORE the proxy routes to avoid being intercepted

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,9 @@ export default defineConfig(({ mode }) => ({
   },
   define: {
     __API_CONFIGS__: JSON.stringify(process.env.API_CONFIGS || ""),
-    __DEFAULT_TENANT__: JSON.stringify(process.env.DEFAULT_TENANT || "business"),
+    __DEFAULT_TENANT__: JSON.stringify(
+      process.env.DEFAULT_TENANT || "business",
+    ),
     __DEFAULT_LANGUAGE__: JSON.stringify(process.env.DEFAULT_LANGUAGE || "en"),
   },
 }));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,11 @@ export default defineConfig(({ mode }) => ({
       "@shared": path.resolve(__dirname, "./shared"),
     },
   },
+  define: {
+    __API_CONFIGS__: JSON.stringify(process.env.API_CONFIGS || ""),
+    __DEFAULT_TENANT__: JSON.stringify(process.env.DEFAULT_TENANT || "business"),
+    __DEFAULT_LANGUAGE__: JSON.stringify(process.env.DEFAULT_LANGUAGE || "en"),
+  },
 }));
 
 function expressPlugin(): Plugin {


### PR DESCRIPTION
## Purpose

The user wanted to eliminate the need for making a fetch request to `/api/config` and instead load API configurations directly from environment variables at build time.

## Code changes

- **Removed async/await pattern**: Changed `apiManager.initialize()` from async to synchronous method
- **Replaced fetch with build-time variables**: API configurations now loaded from `__API_CONFIGS__` global variable instead of runtime API call
- **Added Vite build-time definitions**: Configured Vite to inject environment variables (`API_CONFIGS`, `DEFAULT_TENANT`, `DEFAULT_LANGUAGE`) as global constants
- **Created config utilities**: Added `client/lib/config.ts` with helper functions for accessing build-time configuration
- **Removed server config endpoint**: Deleted `/api/config` route and handler since configuration is now handled at build time
- **Updated TypeScript declarations**: Added type definitions for the new global constants in `vite-env.d.ts`

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a2b1dd34da0b42799fe85057962098b6/zen-field)

👀 [Preview Link](https://a2b1dd34da0b42799fe85057962098b6-zen-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a2b1dd34da0b42799fe85057962098b6</projectId>-->
<!--<branchName>zen-field</branchName>-->