### PR TITLE
Fix API endpoints and dev environment settings visibility

### DIFF
--- a/client/lib/apiManager.ts
+++ b/client/lib/apiManager.ts
@@ -62,13 +62,13 @@ class ApiManager {
     }
 
     try {
-      // Make direct calls to the API
+      // Make calls to the proper API endpoints with API name prefix
       const [livenessResponse, readinessResponse] = await Promise.allSettled([
-        fetch(`${api.baseUrl}/liveness`, {
+        fetch(`${api.baseUrl}/api/${api.name}/liveness`, {
           signal: AbortSignal.timeout(5000),
           mode: "cors",
         }),
-        fetch(`${api.baseUrl}/readiness`, {
+        fetch(`${api.baseUrl}/api/${api.name}/readiness`, {
           signal: AbortSignal.timeout(5000),
           mode: "cors",
         }),

--- a/client/pages/MultiApiDashboard.tsx
+++ b/client/pages/MultiApiDashboard.tsx
@@ -391,7 +391,7 @@ export default function MultiApiDashboard() {
               <FileText className="mr-2 h-4 w-4" />
               Documentation
             </TabsTrigger>
-            {import.meta.env.VITE_NODE_ENV === "production" && (
+            {import.meta.env.VITE_NODE_ENV !== "production" && (
               <TabsTrigger value="settings" className="text-sm">
                 <Settings className="mr-2 h-4 w-4" />
                 Settings

--- a/client/pages/MultiApiDashboard.tsx
+++ b/client/pages/MultiApiDashboard.tsx
@@ -1149,7 +1149,7 @@ export default function MultiApiDashboard() {
             </Card>
           </TabsContent>
 
-          {import.meta.env.VITE_NODE_ENV === "production" && (
+          {import.meta.env.VITE_NODE_ENV !== "production" && (
             <TabsContent value="settings" className="space-y-6">
               <Card>
                 <CardHeader>

--- a/client/pages/MultiApiDashboard.tsx
+++ b/client/pages/MultiApiDashboard.tsx
@@ -377,7 +377,7 @@ export default function MultiApiDashboard() {
           className="space-y-6"
         >
           <TabsList
-            className={`grid w-full h-auto ${import.meta.env.VITE_NODE_ENV === "production" ? "grid-cols-4" : "grid-cols-3"}`}
+            className={`grid w-full h-auto ${import.meta.env.VITE_NODE_ENV !== "production" ? "grid-cols-4" : "grid-cols-3"}`}
           >
             <TabsTrigger value="overview" className="text-sm">
               <Activity className="mr-2 h-4 w-4" />

--- a/client/pages/MultiApiDashboard.tsx
+++ b/client/pages/MultiApiDashboard.tsx
@@ -279,7 +279,7 @@ export default function MultiApiDashboard() {
         toast.error("Selected API not found");
         return;
       }
-      const result = await apiManager.callApi(api.name, "/openapi.json");
+      const result = await apiManager.callApi(api.name, "/api/infractions/openapi.json");
       setOpenApiSpec(result);
       toast.success("Documentation loaded successfully!");
     } catch (error) {

--- a/client/pages/MultiApiDashboard.tsx
+++ b/client/pages/MultiApiDashboard.tsx
@@ -279,7 +279,7 @@ export default function MultiApiDashboard() {
         toast.error("Selected API not found");
         return;
       }
-      const result = await apiManager.callApi(api.name, "/api/infractions/openapi.json");
+      const result = await apiManager.callApi(api.name, `/api/${api.name}/openapi.json`);
       setOpenApiSpec(result);
       toast.success("Documentation loaded successfully!");
     } catch (error) {

--- a/client/pages/MultiApiDashboard.tsx
+++ b/client/pages/MultiApiDashboard.tsx
@@ -279,7 +279,10 @@ export default function MultiApiDashboard() {
         toast.error("Selected API not found");
         return;
       }
-      const result = await apiManager.callApi(api.name, `/api/infractions/openapi.json`);
+      const result = await apiManager.callApi(
+        api.name,
+        `/api/infractions/openapi.json`,
+      );
       setOpenApiSpec(result);
       toast.success("Documentation loaded successfully!");
     } catch (error) {

--- a/client/pages/MultiApiDashboard.tsx
+++ b/client/pages/MultiApiDashboard.tsx
@@ -279,7 +279,7 @@ export default function MultiApiDashboard() {
         toast.error("Selected API not found");
         return;
       }
-      const result = await apiManager.callApi(api.name, `/api/${api.name}/openapi.json`);
+      const result = await apiManager.callApi(api.name, `/api/infractions/openapi.json`);
       setOpenApiSpec(result);
       toast.success("Documentation loaded successfully!");
     } catch (error) {


### PR DESCRIPTION
## Purpose

Fix health check endpoints to use proper API name prefixes and correct OpenAPI documentation URL paths. Also ensure settings tab is only visible in development environment instead of production.

## Code changes

- **Health check endpoints**: Updated liveness and readiness checks to use `/api/{apiname}/liveness` and `/api/{apiname}/readiness` format instead of direct `/liveness` and `/readiness` paths
- **OpenAPI documentation**: Changed documentation endpoint to fetch from `/api/infractions/openapi.json` instead of `/openapi.json`
- **Settings visibility**: Fixed environment condition to show settings tab in development (`!== "production"`) instead of production (`=== "production"`)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 16`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a2b1dd34da0b42799fe85057962098b6/flare-lab)

👀 [Preview Link](https://a2b1dd34da0b42799fe85057962098b6-flare-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a2b1dd34da0b42799fe85057962098b6</projectId>-->
<!--<branchName>flare-lab</branchName>-->